### PR TITLE
Add subdirectories for mobile file work

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,3 @@
+# Exclude native mobile specific files from Heroku
+/ios
+/android

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,1 @@
+Android specific react files if we do a mobile client on Android

--- a/config/default.json
+++ b/config/default.json
@@ -12,11 +12,5 @@
     "seeds": {
       "directory": "db/seeds"
     }
-  },
-
-  "passport": {
-    "Google": {},
-    "Facebook": {},
-    "Twitter": {}
   }
 }

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,1 @@
+IOS client files, React Native code, etc. These are excluded from Heroku since we will be distributing from a separate channel


### PR DESCRIPTION
Server is our server, client is specifically the web client that a user sees when they visit our server. To avoid deploying our mobile code to Heroku we create ios and android folders (which will then contain all the various config files for these projects), and put these folders in the .slugignore.