### PR TITLE
Add object rest spread to webpack and eslint

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["latest"]
+  "presets": ["latest"],
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,8 @@ module.exports = {
     ecmaVersion: 6,
     sourceType: "module",
     ecmaFeatures: {
-      'jsx': true
+      'jsx': true,
+      "experimentalObjectRestSpread": true
     }
   },
   rules: {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "course.thesis",
+  "name": "lote",
   "version": "1.0.0",
   "engines": {
     "node": ">=6.4.0"
@@ -12,13 +12,14 @@
     "build": "webpack --watch",
     "heroku-postbuild": "knex migrate:latest && webpack -p --config webpack.config.babel.js"
   },
-  "author": "Hack Reactor",
+  "author": "Alana Turangan, Connor Wilson, Edward Kim, Ivana He",
   "license": "MIT",
   "dependencies": {
     "axios": "^0.16.1",
     "babel-core": "^6.24.1",
     "babel-loader": "^7.0.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.0",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-latest": "^6.24.0",
     "babel-preset-react": "^6.23.0",
     "bcrypt-nodejs": "^0.0.3",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -16,7 +16,8 @@ const config = {
         use: [
           { loader: 'babel-loader',
             options: {
-              presets: ['react', 'es2015']
+              presets: ['react', 'es2015'],
+              plugins: [require('babel-plugin-transform-object-rest-spread')]
             }
           }
         ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -396,6 +396,10 @@ babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
 babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
@@ -589,6 +593,13 @@ babel-plugin-transform-flow-strip-types@^6.22.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz#84cb672935d43714fdc32bce84568d87441cf7cf"
   dependencies:
     babel-plugin-syntax-flow "^6.18.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz#875d6bc9be761c58a2ae3feee5dc4895d8c7f921"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-react-display-name@^6.23.0:


### PR DESCRIPTION
It isn't enabled by default and is very useful for props passing